### PR TITLE
Add one-time support prompt to plugin

### DIFF
--- a/src-2.0/PluginUI.tsx
+++ b/src-2.0/PluginUI.tsx
@@ -6,16 +6,55 @@ import { ConfigurationContextProvider } from "./contexts/ConfigurationContext";
 import { SearchContextProvider } from "./contexts/SearchContext";
 import { ThemeProvider, useTheme } from "./contexts/ThemeContext";
 import { ToastProvider } from "./contexts/ToastContext";
+import { SupportToast } from "./components/SupportToast";
+import { useLaunchTracking } from "./hooks/hooks";
 import React from "preact/compat";
 import { h } from "preact";
 
 const ThemedApp = () => {
   const { theme } = useTheme();
+  const { shouldShowPrompt, markAsSeen, resetCount } = useLaunchTracking(3);
+
+  const handleStar = () => {
+    window.open("https://github.com/mnttnm/figma-variable-explorer", "_blank");
+    markAsSeen();
+  };
+
+  const handleSponsor = () => {
+    window.open("https://github.com/sponsors/mnttnm", "_blank");
+    markAsSeen();
+  };
+
+  const handleRemindLater = () => {
+    resetCount();
+  };
+
+  const handleClose = () => {
+    markAsSeen();
+  };
 
   return (
     <div className={`${styles.pluginContainer} ${styles[`theme-${theme}`]}`}>
       <Header />
       <Variables />
+
+      {/* Support Toast Container */}
+      {shouldShowPrompt && (
+        <div style={{
+          position: 'fixed',
+          bottom: '16px',
+          right: '16px',
+          zIndex: 10001,
+          pointerEvents: 'none'
+        }}>
+          <SupportToast
+            onClose={handleClose}
+            onStar={handleStar}
+            onSponsor={handleSponsor}
+            onRemindLater={handleRemindLater}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src-2.0/PluginUI.tsx
+++ b/src-2.0/PluginUI.tsx
@@ -13,7 +13,7 @@ import { h } from "preact";
 
 const ThemedApp = () => {
   const { theme } = useTheme();
-  const { shouldShowPrompt, markAsSeen, resetCount } = useLaunchTracking(3);
+  const { shouldShowPrompt, markAsSeen, dismissPrompt } = useLaunchTracking(3);
 
   const handleStar = () => {
     window.open("https://github.com/mnttnm/figma-variable-explorer", "_blank");
@@ -26,7 +26,7 @@ const ThemedApp = () => {
   };
 
   const handleRemindLater = () => {
-    resetCount();
+    dismissPrompt();
   };
 
   const handleClose = () => {

--- a/src-2.0/components/Header.tsx
+++ b/src-2.0/components/Header.tsx
@@ -9,7 +9,6 @@ import {
 import styles from "../style.css";
 import IconButton from "./IconButton";
 import {
-  SearchIcon,
   SliderMenuIcon,
   CopyIcon,
   VerticalMore,
@@ -17,10 +16,6 @@ import {
 import CollectionsSelector from "./CollectionsSelector";
 import ConfigurationContext from "../contexts/ConfigurationContext";
 import { VariablesContext } from "../contexts/VariablesContext";
-import {
-  SearchContext,
-  SearchContextState,
-} from "../contexts/SearchContext";
 import SearchBar from "./SearchBar";
 import { useEscape } from "../hooks/hooks";
 import { Popover, ViewConfigurationPopover } from "./Popover";
@@ -37,9 +32,6 @@ export default function Header() {
   } = useContext(ConfigurationContext)!;
 
   const { handleCopyContent } = useContext(VariablesContext)!;
-
-  const { isSearchActive, setIsSearchActive } =
-    useContext<SearchContextState>(SearchContext);
 
   const [exportContentType, setExportContentType] = useState<ExportContentType>("markdown");
 
@@ -86,34 +78,29 @@ export default function Header() {
 
   return (
     <header class={styles.header}>
-      {isSearchActive ? (
-        <SearchBar />
-      ) : (
-        <Fragment>
-          <CollectionsSelector />
+      <Fragment>
+        <CollectionsSelector />
+        {variableViewMode === "table" && (
+          <div style={{ flex: 1, marginLeft: '12px', marginRight: '12px' }}>
+            <SearchBar />
+          </div>
+        )}
+        {variableViewMode !== "table" && (
           <div style={{ flex: 1 }}></div>
-          <div class={styles["actions-box"]}>
-            {variableViewMode !== "table" && (
-              <IconButton
-                showBorder
-                onClick={handleCopyContent}
-                title={`Copy ${variableViewMode
-                  .toString()
-                  .toUpperCase()}`}
-              >
-                <CopyIcon />
-              </IconButton>
-            )}
-            {variableViewMode === "table" && (
-              <IconButton
-                showBorder
-                onClick={() => setIsSearchActive(true)}
-                title="Search"
-              >
-                <SearchIcon />
-              </IconButton>
-            )}
-            <div className={styles.configurationBoxContainer}>
+        )}
+        <div class={styles["actions-box"]}>
+          {variableViewMode !== "table" && (
+            <IconButton
+              showBorder
+              onClick={handleCopyContent}
+              title={`Copy ${variableViewMode
+                .toString()
+                .toUpperCase()}`}
+            >
+              <CopyIcon />
+            </IconButton>
+          )}
+          <div className={styles.configurationBoxContainer}>
               <IconButton
                 showBorder
                 onClick={() => {
@@ -181,7 +168,6 @@ export default function Header() {
             </div>
           </div>
         </Fragment>
-      )}
     </header>
   );
 }

--- a/src-2.0/components/LoadingSpinner.tsx
+++ b/src-2.0/components/LoadingSpinner.tsx
@@ -1,0 +1,16 @@
+import { h } from "preact";
+import React from "preact/compat";
+import styles from "../style.css";
+
+export const LoadingSpinner = () => {
+  return (
+    <div className={styles.loadingContainer}>
+      <div className={styles.spinner}>
+        <div className={styles.spinnerRing}></div>
+        <div className={styles.spinnerRing}></div>
+        <div className={styles.spinnerRing}></div>
+      </div>
+      <p className={styles.loadingText}>Loading variables...</p>
+    </div>
+  );
+};

--- a/src-2.0/components/SearchBar.tsx
+++ b/src-2.0/components/SearchBar.tsx
@@ -6,7 +6,6 @@ import {
 import styles from "../style.css";
 import IconButton from "./IconButton";
 import { CloseIcon } from "./icons";
-import { useEscape } from "../hooks/hooks";
 import { VariablesContext } from "../contexts/VariablesContext";
 import React from "preact/compat";
 import { h } from "preact";
@@ -15,16 +14,19 @@ const SearchBar = () => {
   const {
     currentSearchTerm,
     setCurrentSearchTerm,
-    setIsSearchActive,
   } = useContext(SearchContext) as SearchContextState;
 
-  useEscape(() => setIsSearchActive(false));
   const { activeCollection, collections } =
     useContext(VariablesContext)!;
 
   // Smart truncation for long collection names
   const getPlaceholderText = () => {
-    const collectionName = collections[activeCollection!].name;
+    // Safety check for collections not yet loaded or activeCollection not set
+    if (!collections || activeCollection === undefined || activeCollection === null || !collections[activeCollection]) {
+      return "Search variables (Cmd/Ctrl+F)";
+    }
+
+    const collectionName = collections[activeCollection].name;
     const maxLength = 20;
     if (collectionName.length > maxLength) {
       return `Search ${collectionName.substring(0, maxLength)}... (Cmd/Ctrl+F)`;
@@ -47,7 +49,6 @@ const SearchBar = () => {
           setCurrentSearchTerm((e.target as HTMLInputElement).value)
         }
         className={styles.searchInput}
-        autoFocus
       />
       {currentSearchTerm && (
         <IconButton
@@ -58,13 +59,6 @@ const SearchBar = () => {
           <CloseIcon />
         </IconButton>
       )}
-      <IconButton
-        showBorder
-        onClick={() => setIsSearchActive(false)}
-        title="Exit Search"
-      >
-        <CloseIcon />
-      </IconButton>
     </div>
   );
 };

--- a/src-2.0/components/SupportToast.tsx
+++ b/src-2.0/components/SupportToast.tsx
@@ -90,6 +90,29 @@ export const SupportToast = ({
             Remind me later
           </button>
         </div>
+
+        <div className={styles.supportToastSocials}>
+          <span className={styles.supportToastSocialsLabel}>Say hi:</span>
+          <a
+            href="https://www.linkedin.com/in/tatermohit/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.supportToastSocialLink}
+            onClick={(e) => e.stopPropagation()}
+          >
+            LinkedIn
+          </a>
+          <span className={styles.supportToastSocialsSeparator}>•</span>
+          <a
+            href="https://twitter.com/tatermohit"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.supportToastSocialLink}
+            onClick={(e) => e.stopPropagation()}
+          >
+            Twitter
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/src-2.0/components/SupportToast.tsx
+++ b/src-2.0/components/SupportToast.tsx
@@ -19,28 +19,28 @@ export const SupportToast = ({
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
-    // Trigger animation on mount with a slight delay
-    const timer = setTimeout(() => setIsVisible(true), 100);
+    // Trigger animation on mount with a slight delay for smoother entrance
+    const timer = setTimeout(() => setIsVisible(true), 150);
     return () => clearTimeout(timer);
   }, []);
 
-  // Auto-dismiss after 15 seconds
+  // Auto-dismiss after 12 seconds
   useEffect(() => {
     const autoDismiss = setTimeout(() => {
       handleClose();
-    }, 15000);
+    }, 12000);
     return () => clearTimeout(autoDismiss);
   }, []);
 
   const handleClose = () => {
     setIsVisible(false);
-    setTimeout(onClose, 300);
+    setTimeout(onClose, 400);
   };
 
   const handleAction = (action: () => void) => {
     action();
     setIsVisible(false);
-    setTimeout(onClose, 300);
+    setTimeout(onClose, 400);
   };
 
   return (
@@ -61,38 +61,38 @@ export const SupportToast = ({
       </button>
 
       <div className={styles.supportToastContent}>
-        <div className={styles.supportToastMessage}>
-          <div className={styles.supportToastTitle}>
-            👋 You've been exploring variables with us for a bit!
-          </div>
-          <div className={styles.supportToastSubtitle}>
-            If it's saving you time, a star or sponsorship would mean the world and help keep this free.
-          </div>
+        <div className={styles.supportToastHeader}>
+          <span className={styles.supportToastIcon}>👋</span>
+          <span className={styles.supportToastTitle}>Enjoying variables?</span>
+        </div>
+
+        <div className={styles.supportToastBody}>
+          Support with a ⭐ or 💝 to keep it free!
         </div>
 
         <div className={styles.supportToastActions}>
           <button
-            className={`${styles.supportToastButton} ${styles.supportToastButtonPrimary}`}
+            className={`${styles.supportToastButton} ${styles.supportToastButtonStar}`}
             onClick={() => handleAction(onStar)}
           >
-            ⭐ Star on GitHub
+            ⭐ GitHub
           </button>
           <button
-            className={`${styles.supportToastButton} ${styles.supportToastButtonPrimary}`}
+            className={`${styles.supportToastButton} ${styles.supportToastButtonSponsor}`}
             onClick={() => handleAction(onSponsor)}
           >
             💝 Sponsor
           </button>
-          <button
-            className={`${styles.supportToastButton} ${styles.supportToastButtonSecondary}`}
-            onClick={() => handleAction(onRemindLater)}
-          >
-            Remind me later
-          </button>
         </div>
 
-        <div className={styles.supportToastSocials}>
-          <span className={styles.supportToastSocialsLabel}>Say hi:</span>
+        <div className={styles.supportToastFooter}>
+          <button
+            className={styles.supportToastLaterLink}
+            onClick={() => handleAction(onRemindLater)}
+          >
+            Later
+          </button>
+          <span className={styles.supportToastSocialsSeparator}>•</span>
           <a
             href="https://www.linkedin.com/in/tatermohit/"
             target="_blank"

--- a/src-2.0/components/SupportToast.tsx
+++ b/src-2.0/components/SupportToast.tsx
@@ -1,5 +1,5 @@
 import { h } from "preact";
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useState, useRef } from "preact/hooks";
 import React from "preact/compat";
 import styles from "../style.css";
 
@@ -17,6 +17,7 @@ export const SupportToast = ({
   onRemindLater
 }: SupportToastProps) => {
   const [isVisible, setIsVisible] = useState(false);
+  const autoDismissTimer = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     // Trigger animation on mount with a slight delay
@@ -26,18 +27,28 @@ export const SupportToast = ({
 
   // Auto-dismiss after 15 seconds
   useEffect(() => {
-    const autoDismiss = setTimeout(() => {
+    autoDismissTimer.current = setTimeout(() => {
       handleClose();
     }, 15000);
-    return () => clearTimeout(autoDismiss);
+    return () => {
+      if (autoDismissTimer.current) clearTimeout(autoDismissTimer.current);
+    };
   }, []);
 
   const handleClose = () => {
+    if (autoDismissTimer.current) {
+      clearTimeout(autoDismissTimer.current);
+      autoDismissTimer.current = null;
+    }
     setIsVisible(false);
     setTimeout(onClose, 300);
   };
 
   const handleAction = (action: () => void) => {
+    if (autoDismissTimer.current) {
+      clearTimeout(autoDismissTimer.current);
+      autoDismissTimer.current = null;
+    }
     action();
     setIsVisible(false);
     setTimeout(onClose, 300);

--- a/src-2.0/components/SupportToast.tsx
+++ b/src-2.0/components/SupportToast.tsx
@@ -40,7 +40,7 @@ export const SupportToast = ({
     const timeout = prefersReducedMotion ? autoDismissMs * 2 : autoDismissMs;
 
     autoDismissTimer.current = setTimeout(() => {
-      handleClose();
+      handleRemindLater();
     }, timeout);
 
     return () => {
@@ -65,6 +65,16 @@ export const SupportToast = ({
     action();
     setIsVisible(false);
     setTimeout(onClose, 400);
+  };
+
+  const handleRemindLater = () => {
+    if (autoDismissTimer.current) {
+      clearTimeout(autoDismissTimer.current);
+      autoDismissTimer.current = null;
+    }
+    setIsVisible(false);
+    // Don't call onClose - just call onRemindLater to dismiss without marking as seen
+    setTimeout(onRemindLater, 400);
   };
 
   return (
@@ -106,15 +116,16 @@ export const SupportToast = ({
           >
             Sponsor
           </button>
-        </div>
-
-        <div className={styles.supportToastFooter}>
           <button
-            className={styles.supportToastLaterLink}
-            onClick={() => handleAction(onRemindLater)}
+            className={`${styles.supportToastButton} ${styles.supportToastButtonTertiary}`}
+            onClick={handleRemindLater}
           >
             Remind Later
           </button>
+        </div>
+
+        <div className={styles.supportToastFooter}>
+          <span className={styles.supportToastGreeting}>Hello</span>
           <span className={styles.supportToastSocialsSeparator}>•</span>
           <a
             href="https://www.linkedin.com/in/tatermohit/"

--- a/src-2.0/components/SupportToast.tsx
+++ b/src-2.0/components/SupportToast.tsx
@@ -1,0 +1,96 @@
+import { h } from "preact";
+import { useEffect, useState } from "preact/hooks";
+import React from "preact/compat";
+import styles from "../style.css";
+
+interface SupportToastProps {
+  onClose: () => void;
+  onStar: () => void;
+  onSponsor: () => void;
+  onRemindLater: () => void;
+}
+
+export const SupportToast = ({
+  onClose,
+  onStar,
+  onSponsor,
+  onRemindLater
+}: SupportToastProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    // Trigger animation on mount with a slight delay
+    const timer = setTimeout(() => setIsVisible(true), 100);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // Auto-dismiss after 15 seconds
+  useEffect(() => {
+    const autoDismiss = setTimeout(() => {
+      handleClose();
+    }, 15000);
+    return () => clearTimeout(autoDismiss);
+  }, []);
+
+  const handleClose = () => {
+    setIsVisible(false);
+    setTimeout(onClose, 300);
+  };
+
+  const handleAction = (action: () => void) => {
+    action();
+    setIsVisible(false);
+    setTimeout(onClose, 300);
+  };
+
+  return (
+    <div
+      className={`${styles.supportToast} ${
+        isVisible ? styles.supportToastVisible : ''
+      }`}
+      style={{
+        pointerEvents: 'auto'
+      }}
+    >
+      <button
+        className={styles.supportToastCloseButton}
+        onClick={handleClose}
+        aria-label="Close notification"
+      >
+        ×
+      </button>
+
+      <div className={styles.supportToastContent}>
+        <div className={styles.supportToastMessage}>
+          <div className={styles.supportToastTitle}>
+            👋 You've been exploring variables with us for a bit!
+          </div>
+          <div className={styles.supportToastSubtitle}>
+            If it's saving you time, a star or sponsorship would mean the world and help keep this free.
+          </div>
+        </div>
+
+        <div className={styles.supportToastActions}>
+          <button
+            className={`${styles.supportToastButton} ${styles.supportToastButtonPrimary}`}
+            onClick={() => handleAction(onStar)}
+          >
+            ⭐ Star on GitHub
+          </button>
+          <button
+            className={`${styles.supportToastButton} ${styles.supportToastButtonPrimary}`}
+            onClick={() => handleAction(onSponsor)}
+          >
+            💝 Sponsor
+          </button>
+          <button
+            className={`${styles.supportToastButton} ${styles.supportToastButtonSecondary}`}
+            onClick={() => handleAction(onRemindLater)}
+          >
+            Remind me later
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src-2.0/hooks/hooks.tsx
+++ b/src-2.0/hooks/hooks.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "preact/hooks";
 import { emit, on } from "@create-figma-plugin/utilities";
+import type { LaunchData } from "../types";
 
 export const useEscape = (onEscape: () => void) => {
   useEffect(() => {
@@ -16,11 +17,6 @@ export const useEscape = (onEscape: () => void) => {
     };
   }, [onEscape]);
 };
-
-interface LaunchData {
-  launchCount: number;
-  hasSeenPrompt: boolean;
-}
 
 export const useLaunchTracking = (
   targetLaunchCount: number = 3

--- a/src-2.0/hooks/hooks.tsx
+++ b/src-2.0/hooks/hooks.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
+import { emit, on } from "@create-figma-plugin/utilities";
 
 export const useEscape = (onEscape: () => void) => {
   useEffect(() => {
@@ -14,4 +15,59 @@ export const useEscape = (onEscape: () => void) => {
       document.removeEventListener("keydown", handleEscKey);
     };
   }, [onEscape]);
+};
+
+interface LaunchData {
+  launchCount: number;
+  hasSeenPrompt: boolean;
+}
+
+export const useLaunchTracking = (
+  targetLaunchCount: number = 3
+): {
+  shouldShowPrompt: boolean;
+  markAsSeen: () => void;
+  resetCount: () => void;
+} => {
+  const [shouldShowPrompt, setShouldShowPrompt] = useState(false);
+
+  useEffect(() => {
+    // Listen for launch data from main thread
+    const unsubscribe = on("LAUNCH_DATA", (data: LaunchData) => {
+      const { launchCount, hasSeenPrompt } = data;
+
+      // Show prompt if user has launched plugin the target number of times
+      // and hasn't seen the prompt yet
+      if (launchCount === targetLaunchCount && !hasSeenPrompt) {
+        // Delay showing the prompt by 3 seconds
+        setTimeout(() => {
+          setShouldShowPrompt(true);
+        }, 3000);
+      }
+    });
+
+    // Track this launch
+    emit("TRACK_LAUNCH");
+
+    return () => {
+      unsubscribe();
+    };
+  }, [targetLaunchCount]);
+
+  const markAsSeen = () => {
+    emit("MARK_SUPPORT_PROMPT_SEEN");
+    setShouldShowPrompt(false);
+  };
+
+  const resetCount = () => {
+    // Reset is handled by not marking as seen
+    // This allows the prompt to appear again after another 3 launches
+    setShouldShowPrompt(false);
+  };
+
+  return {
+    shouldShowPrompt,
+    markAsSeen,
+    resetCount,
+  };
 };

--- a/src-2.0/hooks/hooks.tsx
+++ b/src-2.0/hooks/hooks.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "preact/hooks";
 import { emit, on } from "@create-figma-plugin/utilities";
+import { LaunchData } from "../types";
 
 export const useEscape = (onEscape: () => void) => {
   useEffect(() => {
@@ -17,17 +18,12 @@ export const useEscape = (onEscape: () => void) => {
   }, [onEscape]);
 };
 
-interface LaunchData {
-  launchCount: number;
-  hasSeenPrompt: boolean;
-}
-
 export const useLaunchTracking = (
   targetLaunchCount: number = 3
 ): {
   shouldShowPrompt: boolean;
   markAsSeen: () => void;
-  resetCount: () => void;
+  dismissPrompt: () => void;
 } => {
   const [shouldShowPrompt, setShouldShowPrompt] = useState(false);
 
@@ -59,8 +55,8 @@ export const useLaunchTracking = (
     setShouldShowPrompt(false);
   };
 
-  const resetCount = () => {
-    // Reset is handled by not marking as seen
+  const dismissPrompt = () => {
+    // Only hides the prompt from view, does not reset launch count or mark as seen
     // This allows the prompt to appear again after another 3 launches
     setShouldShowPrompt(false);
   };
@@ -68,6 +64,6 @@ export const useLaunchTracking = (
   return {
     shouldShowPrompt,
     markAsSeen,
-    resetCount,
+    dismissPrompt,
   };
 };

--- a/src-2.0/main.ts
+++ b/src-2.0/main.ts
@@ -14,6 +14,8 @@ import {
   GetVariableHandler,
   InternalVariable,
   ResizeWindowHandler,
+  TrackLaunchHandler,
+  MarkSupportPromptSeenHandler,
   VariableViewMode,
 } from "./types";
 import {
@@ -33,6 +35,30 @@ export default function () {
 
   once<CloseHandler>("CLOSE", function () {
     figma.closePlugin();
+  });
+
+  // Track plugin launches for support prompt
+  on<TrackLaunchHandler>("TRACK_LAUNCH", async function () {
+    try {
+      const launchCount = (await figma.clientStorage.getAsync("launchCount")) || 0;
+      const hasSeenPrompt = (await figma.clientStorage.getAsync("hasSeenSupportPrompt")) || false;
+
+      const newCount = launchCount + 1;
+      await figma.clientStorage.setAsync("launchCount", newCount);
+
+      emit("LAUNCH_DATA", { launchCount: newCount, hasSeenPrompt });
+    } catch (error) {
+      console.error("Error tracking launch:", error);
+    }
+  });
+
+  // Mark support prompt as seen
+  on<MarkSupportPromptSeenHandler>("MARK_SUPPORT_PROMPT_SEEN", async function () {
+    try {
+      await figma.clientStorage.setAsync("hasSeenSupportPrompt", true);
+    } catch (error) {
+      console.error("Error marking support prompt as seen:", error);
+    }
   });
 
   on<GetJsonDataHandler>(

--- a/src-2.0/main.ts
+++ b/src-2.0/main.ts
@@ -16,6 +16,7 @@ import {
   ResizeWindowHandler,
   TrackLaunchHandler,
   MarkSupportPromptSeenHandler,
+  DismissSupportPromptHandler,
   VariableViewMode,
 } from "./types";
 import {
@@ -42,11 +43,16 @@ export default function () {
     try {
       const launchCount = (await figma.clientStorage.getAsync("launchCount")) || 0;
       const hasSeenPrompt = (await figma.clientStorage.getAsync("hasSeenSupportPrompt")) || false;
+      const lastDismissLaunchCount = (await figma.clientStorage.getAsync("lastDismissLaunchCount")) || null;
 
       const newCount = launchCount + 1;
       await figma.clientStorage.setAsync("launchCount", newCount);
 
-      emit("LAUNCH_DATA", { launchCount: newCount, hasSeenPrompt });
+      emit("LAUNCH_DATA", {
+        launchCount: newCount,
+        hasSeenPrompt,
+        lastDismissLaunchCount
+      });
     } catch (error) {
       console.error("Error tracking launch:", error);
     }
@@ -58,6 +64,15 @@ export default function () {
       await figma.clientStorage.setAsync("hasSeenSupportPrompt", true);
     } catch (error) {
       console.error("Error marking support prompt as seen:", error);
+    }
+  });
+
+  // Dismiss support prompt (for "Remind Later" and auto-dismiss)
+  on<DismissSupportPromptHandler>("DISMISS_SUPPORT_PROMPT", async function (currentLaunchCount) {
+    try {
+      await figma.clientStorage.setAsync("lastDismissLaunchCount", currentLaunchCount);
+    } catch (error) {
+      console.error("Error dismissing support prompt:", error);
     }
   });
 

--- a/src-2.0/screens/Variables.tsx
+++ b/src-2.0/screens/Variables.tsx
@@ -7,7 +7,7 @@ import {
   VariableStatus,
 } from "../contexts/VariablesContext";
 import { ValueRenderer } from "../components/ValueRenderer";
-import { SkeletonTable } from "../components/Skeleton";
+import { LoadingSpinner } from "../components/LoadingSpinner";
 import { Tooltip } from "react-tooltip";
 import {
   AliasValue,
@@ -30,12 +30,12 @@ export default function Variables() {
   const { variableViewMode } = useContext(ConfigurationContext)!;
 
   if (status === VariableStatus.LOADING) {
-    return <SkeletonTable />;
+    return <LoadingSpinner />;
   }
 
   if (status === VariableStatus.ERROR) {
     return (
-      <div className={styles["error-state"]}>
+      <div className={`${styles["error-state"]} ${styles.fadeIn}`}>
         <div className={styles["error-state-icon"]}>
           <WarningIcon />
         </div>
@@ -47,7 +47,7 @@ export default function Variables() {
 
   if (!data || !cssData || !jsonData || (data && Object.keys(data).length === 0)) {
     return (
-      <div className={styles["empty-state"]}>
+      <div className={`${styles["empty-state"]} ${styles.fadeIn}`}>
         <div className={styles["empty-state-icon"]}>
           <EmptyIcon />
         </div>
@@ -245,7 +245,7 @@ const TabularView = (collectionData: CollectionVariables) => {
   // Show empty state if search returns no results
   if (rows.length === 0 && currentSearchTerm) {
     return (
-      <main className={styles.tableContainer}>
+      <main className={`${styles.tableContainer} ${styles.fadeIn}`}>
         <div className={styles["empty-state"]}>
           <div className={styles["empty-state-icon"]}>
             <SearchIconLarge />
@@ -260,7 +260,7 @@ const TabularView = (collectionData: CollectionVariables) => {
   }
 
   return (
-    <main className={styles.tableContainer}>
+    <main className={`${styles.tableContainer} ${styles.fadeIn}`}>
       <Tooltip
         id="alias-tooltip"
         className={[styles.tooltip, styles.aliasTooltip].join(" ")}
@@ -342,12 +342,12 @@ const TabularView = (collectionData: CollectionVariables) => {
 };
 
 const CSSView = (data: any) => {
-  return <pre className={styles.cssViewContainer}>{data}</pre>;
+  return <pre className={`${styles.cssViewContainer} ${styles.fadeIn}`}>{data}</pre>;
 };
 
 const JSONView = (collectionData: JSONData) => {
   return (
-    <pre className={styles.jsonViewContainer}>
+    <pre className={`${styles.jsonViewContainer} ${styles.fadeIn}`}>
       {JSON.stringify(collectionData, null, 2)}
     </pre>
   );

--- a/src-2.0/style.css
+++ b/src-2.0/style.css
@@ -1585,180 +1585,199 @@ dl {
   line-height: 1.5;
 }
 
-/* Support Toast */
+/* Support Toast - Compact Design */
 .supportToast {
-  background: var(--sds-color-background-default-secondary);
-  border: 1px solid var(--sds-color-border-brand-default);
-  border-radius: var(--sds-size-radius-200);
-  box-shadow: var(--sds-size-depth-0) var(--sds-size-depth-600)
-    var(--sds-size-depth-1200) var(--sds-size-depth-negative-200)
-    var(--sds-color-black-500);
-  min-width: 320px;
-  max-width: 420px;
+  background: var(--sds-color-background-default-default);
+  border: 1px solid var(--sds-color-border-default-default);
+  border-radius: 10px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15),
+              0 2px 4px rgba(0, 0, 0, 0.1);
+  width: 300px;
   opacity: 0;
-  transform: translateX(120%);
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  transform: translateY(20px);
+  transition: all 0.5s cubic-bezier(0.16, 1, 0.3, 1);
   position: relative;
-  overflow: hidden;
-}
-
-.supportToast::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: linear-gradient(
-    90deg,
-    var(--sds-color-brand-500) 0%,
-    var(--sds-color-pink-500) 50%,
-    var(--sds-color-brand-500) 100%
-  );
-  background-size: 200% 100%;
-  animation: shimmer 3s infinite;
+  backdrop-filter: blur(12px);
 }
 
 .supportToastVisible {
   opacity: 1;
-  transform: translateX(0);
+  transform: translateY(0);
 }
 
 .supportToastContent {
-  padding: var(--sds-size-space-400);
+  padding: 12px 16px;
   display: flex;
   flex-direction: column;
-  gap: var(--sds-size-space-300);
+  gap: 10px;
 }
 
 .supportToastCloseButton {
   position: absolute;
-  top: var(--sds-size-space-200);
-  right: var(--sds-size-space-200);
+  top: 8px;
+  right: 8px;
   background: none;
   border: none;
-  color: var(--sds-color-text-default-secondary);
+  color: var(--sds-color-text-default-tertiary);
   cursor: pointer;
-  font-size: 20px;
-  font-weight: bold;
+  font-size: 18px;
+  font-weight: normal;
   line-height: 1;
-  padding: 0;
-  width: 24px;
-  height: 24px;
+  padding: 4px;
+  width: 20px;
+  height: 20px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--sds-size-radius-100);
-  transition: all 0.2s ease-in-out;
+  border-radius: 4px;
+  transition: all 0.15s ease;
   z-index: 1;
+  opacity: 0.6;
 }
 
 .supportToastCloseButton:hover {
   background: var(--sds-color-background-default-tertiary);
   color: var(--sds-color-text-default-default);
-  transform: scale(1.1);
+  opacity: 1;
 }
 
 .supportToastCloseButton:active {
-  transform: scale(0.95);
+  transform: scale(0.9);
 }
 
-.supportToastMessage {
+.supportToastHeader {
   display: flex;
-  flex-direction: column;
-  gap: var(--sds-size-space-150);
-  padding-right: var(--sds-size-space-600);
+  align-items: center;
+  gap: 8px;
+  padding-right: 24px;
+}
+
+.supportToastIcon {
+  font-size: 16px;
+  line-height: 1;
+  flex-shrink: 0;
 }
 
 .supportToastTitle {
   font-family: var(--sds-typography-body-font-family);
-  font-size: var(--sds-typography-body-size-medium);
-  font-weight: var(--sds-typography-heading-font-weight);
+  font-size: 13px;
+  font-weight: 600;
   color: var(--sds-color-text-default-default);
-  line-height: 1.4;
+  line-height: 1.3;
 }
 
-.supportToastSubtitle {
+.supportToastBody {
   font-family: var(--sds-typography-body-font-family);
-  font-size: var(--sds-typography-body-size-small);
-  font-weight: var(--sds-typography-body-font-weight-regular);
+  font-size: 12px;
+  font-weight: 400;
   color: var(--sds-color-text-default-secondary);
-  line-height: 1.5;
+  line-height: 1.4;
+  padding-left: 24px;
 }
 
 .supportToastActions {
   display: flex;
-  gap: var(--sds-size-space-200);
-  flex-wrap: wrap;
+  gap: 8px;
+  padding-left: 24px;
 }
 
 .supportToastButton {
   font-family: var(--sds-typography-body-font-family);
-  font-size: var(--sds-typography-body-size-small);
-  font-weight: var(--sds-typography-body-font-weight-medium);
-  padding: var(--sds-size-space-150) var(--sds-size-space-300);
-  border-radius: var(--sds-size-radius-100);
-  border: 1px solid transparent;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: none;
   cursor: pointer;
-  transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease;
   white-space: nowrap;
-  flex: 0 1 auto;
+  flex: 0 0 auto;
 }
 
-.supportToastButtonPrimary {
-  background: var(--sds-color-background-brand-default);
-  color: var(--sds-color-text-on-brand-default);
-  border-color: var(--sds-color-border-brand-default);
+.supportToastButtonStar {
+  background: var(--sds-color-gray-900);
+  color: var(--sds-color-white-1000);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
-.supportToastButtonPrimary:hover {
-  background: var(--sds-color-background-brand-hover);
-  border-color: var(--sds-color-border-brand-hover);
+.theme-light .supportToastButtonStar {
+  background: var(--sds-color-gray-1000);
+  color: var(--sds-color-white-1000);
+}
+
+.supportToastButtonStar:hover {
+  background: var(--sds-color-gray-800);
   transform: translateY(-1px);
-  box-shadow: 0 2px 4px var(--sds-color-black-300);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
 }
 
-.supportToastButtonPrimary:active {
+.theme-light .supportToastButtonStar:hover {
+  background: var(--sds-color-gray-900);
+}
+
+.supportToastButtonStar:active {
   transform: translateY(0);
-  box-shadow: none;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
-.supportToastButtonSecondary {
-  background: transparent;
-  color: var(--sds-color-text-default-secondary);
-  border-color: var(--sds-color-border-default-default);
+.supportToastButtonSponsor {
+  background: var(--sds-color-pink-700);
+  color: var(--sds-color-white-1000);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
-.supportToastButtonSecondary:hover {
-  background: var(--sds-color-background-default-tertiary);
-  color: var(--sds-color-text-default-default);
-  border-color: var(--sds-color-border-default-hover);
+.theme-light .supportToastButtonSponsor {
+  background: var(--sds-color-pink-600);
 }
 
-.supportToastButtonSecondary:active {
-  background: var(--sds-color-background-default-secondary);
+.supportToastButtonSponsor:hover {
+  background: var(--sds-color-pink-600);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
 }
 
-.supportToastSocials {
+.theme-light .supportToastButtonSponsor:hover {
+  background: var(--sds-color-pink-500);
+}
+
+.supportToastButtonSponsor:active {
+  transform: translateY(0);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
+.supportToastFooter {
   display: flex;
   align-items: center;
-  gap: var(--sds-size-space-100);
-  font-size: var(--sds-typography-body-size-xsmall);
-  padding-top: var(--sds-size-space-100);
-  border-top: 1px solid var(--sds-color-border-default-default);
-  opacity: 0.6;
+  gap: 6px;
+  font-size: 11px;
+  padding-left: 24px;
+  padding-top: 4px;
+  opacity: 0.7;
 }
 
-.supportToastSocialsLabel {
-  color: var(--sds-color-text-default-tertiary);
-  font-weight: var(--sds-typography-body-font-weight-regular);
+.supportToastLaterLink {
+  background: none;
+  border: none;
+  color: var(--sds-color-text-default-secondary);
+  text-decoration: none;
+  cursor: pointer;
+  padding: 0;
+  font-size: 11px;
+  font-family: var(--sds-typography-body-font-family);
+  font-weight: 400;
+  transition: color 0.15s ease;
+}
+
+.supportToastLaterLink:hover {
+  color: var(--sds-color-text-default-default);
+  text-decoration: underline;
 }
 
 .supportToastSocialLink {
   color: var(--sds-color-text-default-secondary);
   text-decoration: none;
-  transition: color 0.2s ease-in-out;
-  font-weight: var(--sds-typography-body-font-weight-regular);
+  transition: color 0.15s ease;
+  font-weight: 400;
 }
 
 .supportToastSocialLink:hover {
@@ -1768,6 +1787,7 @@ dl {
 
 .supportToastSocialsSeparator {
   color: var(--sds-color-text-default-tertiary);
-  opacity: 0.5;
+  opacity: 0.6;
+  font-size: 10px;
 }
 

--- a/src-2.0/style.css
+++ b/src-2.0/style.css
@@ -1512,6 +1512,83 @@ dl {
   }
 }
 
+/* Loading Spinner */
+.loadingContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  min-height: 100%;
+  padding: var(--sds-size-space-2400);
+}
+
+.spinner {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  margin-bottom: var(--sds-size-space-400);
+}
+
+.spinnerRing {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border: 3px solid transparent;
+  border-top-color: var(--sds-color-border-brand-default);
+  border-radius: 50%;
+  animation: spin 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+}
+
+.spinnerRing:nth-child(1) {
+  animation-delay: -0.45s;
+  opacity: 0.8;
+}
+
+.spinnerRing:nth-child(2) {
+  animation-delay: -0.3s;
+  opacity: 0.6;
+}
+
+.spinnerRing:nth-child(3) {
+  animation-delay: -0.15s;
+  opacity: 0.4;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.loadingText {
+  color: var(--sds-color-text-default-secondary);
+  font-size: var(--sds-typography-body-size-medium);
+  font-weight: 400;
+  margin: 0;
+}
+
+/* Fade-in Animation */
+.fadeIn {
+  animation: fadeIn 0.3s ease-in;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* Empty States */
 .empty-state {
   display: flex;
@@ -1746,6 +1823,26 @@ dl {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
+.supportToastButtonTertiary {
+  background: transparent;
+  color: var(--sds-color-text-default-secondary);
+  border: 1px solid var(--sds-color-border-default-default);
+  box-shadow: none;
+}
+
+.supportToastButtonTertiary:hover {
+  background: var(--sds-color-background-default-secondary);
+  color: var(--sds-color-text-default-default);
+  border-color: var(--sds-color-border-default-secondary);
+  transform: none;
+  box-shadow: none;
+}
+
+.supportToastButtonTertiary:active {
+  background: var(--sds-color-background-default-tertiary);
+  transform: scale(0.98);
+}
+
 .supportToastFooter {
   display: flex;
   align-items: center;
@@ -1754,6 +1851,12 @@ dl {
   padding-left: 24px;
   padding-top: 4px;
   opacity: 0.7;
+}
+
+.supportToastGreeting {
+  color: var(--sds-color-text-default-secondary);
+  font-family: var(--sds-typography-body-font-family);
+  font-weight: 400;
 }
 
 .supportToastLaterLink {

--- a/src-2.0/style.css
+++ b/src-2.0/style.css
@@ -1598,6 +1598,7 @@ dl {
   transition: all 0.5s cubic-bezier(0.16, 1, 0.3, 1);
   position: relative;
   backdrop-filter: blur(12px);
+  pointer-events: auto;
 }
 
 .supportToastVisible {
@@ -1721,23 +1722,23 @@ dl {
 }
 
 .supportToastButtonSponsor {
-  background: var(--sds-color-pink-700);
+  background: var(--sds-color-gray-800);
   color: var(--sds-color-white-1000);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 }
 
 .theme-light .supportToastButtonSponsor {
-  background: var(--sds-color-pink-600);
+  background: var(--sds-color-gray-900);
 }
 
 .supportToastButtonSponsor:hover {
-  background: var(--sds-color-pink-600);
+  background: var(--sds-color-gray-700);
   transform: translateY(-1px);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
 }
 
 .theme-light .supportToastButtonSponsor:hover {
-  background: var(--sds-color-pink-500);
+  background: var(--sds-color-gray-800);
 }
 
 .supportToastButtonSponsor:active {

--- a/src-2.0/style.css
+++ b/src-2.0/style.css
@@ -1739,3 +1739,35 @@ dl {
   background: var(--sds-color-background-default-secondary);
 }
 
+.supportToastSocials {
+  display: flex;
+  align-items: center;
+  gap: var(--sds-size-space-100);
+  font-size: var(--sds-typography-body-size-xsmall);
+  padding-top: var(--sds-size-space-100);
+  border-top: 1px solid var(--sds-color-border-default-default);
+  opacity: 0.6;
+}
+
+.supportToastSocialsLabel {
+  color: var(--sds-color-text-default-tertiary);
+  font-weight: var(--sds-typography-body-font-weight-regular);
+}
+
+.supportToastSocialLink {
+  color: var(--sds-color-text-default-secondary);
+  text-decoration: none;
+  transition: color 0.2s ease-in-out;
+  font-weight: var(--sds-typography-body-font-weight-regular);
+}
+
+.supportToastSocialLink:hover {
+  color: var(--sds-color-text-brand-default);
+  text-decoration: underline;
+}
+
+.supportToastSocialsSeparator {
+  color: var(--sds-color-text-default-tertiary);
+  opacity: 0.5;
+}
+

--- a/src-2.0/style.css
+++ b/src-2.0/style.css
@@ -1585,3 +1585,157 @@ dl {
   line-height: 1.5;
 }
 
+/* Support Toast */
+.supportToast {
+  background: var(--sds-color-background-default-secondary);
+  border: 1px solid var(--sds-color-border-brand-default);
+  border-radius: var(--sds-size-radius-200);
+  box-shadow: var(--sds-size-depth-0) var(--sds-size-depth-600)
+    var(--sds-size-depth-1200) var(--sds-size-depth-negative-200)
+    var(--sds-color-black-500);
+  min-width: 320px;
+  max-width: 420px;
+  opacity: 0;
+  transform: translateX(120%);
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+  overflow: hidden;
+}
+
+.supportToast::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    var(--sds-color-brand-500) 0%,
+    var(--sds-color-pink-500) 50%,
+    var(--sds-color-brand-500) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 3s infinite;
+}
+
+.supportToastVisible {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.supportToastContent {
+  padding: var(--sds-size-space-400);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sds-size-space-300);
+}
+
+.supportToastCloseButton {
+  position: absolute;
+  top: var(--sds-size-space-200);
+  right: var(--sds-size-space-200);
+  background: none;
+  border: none;
+  color: var(--sds-color-text-default-secondary);
+  cursor: pointer;
+  font-size: 20px;
+  font-weight: bold;
+  line-height: 1;
+  padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--sds-size-radius-100);
+  transition: all 0.2s ease-in-out;
+  z-index: 1;
+}
+
+.supportToastCloseButton:hover {
+  background: var(--sds-color-background-default-tertiary);
+  color: var(--sds-color-text-default-default);
+  transform: scale(1.1);
+}
+
+.supportToastCloseButton:active {
+  transform: scale(0.95);
+}
+
+.supportToastMessage {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sds-size-space-150);
+  padding-right: var(--sds-size-space-600);
+}
+
+.supportToastTitle {
+  font-family: var(--sds-typography-body-font-family);
+  font-size: var(--sds-typography-body-size-medium);
+  font-weight: var(--sds-typography-heading-font-weight);
+  color: var(--sds-color-text-default-default);
+  line-height: 1.4;
+}
+
+.supportToastSubtitle {
+  font-family: var(--sds-typography-body-font-family);
+  font-size: var(--sds-typography-body-size-small);
+  font-weight: var(--sds-typography-body-font-weight-regular);
+  color: var(--sds-color-text-default-secondary);
+  line-height: 1.5;
+}
+
+.supportToastActions {
+  display: flex;
+  gap: var(--sds-size-space-200);
+  flex-wrap: wrap;
+}
+
+.supportToastButton {
+  font-family: var(--sds-typography-body-font-family);
+  font-size: var(--sds-typography-body-size-small);
+  font-weight: var(--sds-typography-body-font-weight-medium);
+  padding: var(--sds-size-space-150) var(--sds-size-space-300);
+  border-radius: var(--sds-size-radius-100);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  white-space: nowrap;
+  flex: 0 1 auto;
+}
+
+.supportToastButtonPrimary {
+  background: var(--sds-color-background-brand-default);
+  color: var(--sds-color-text-on-brand-default);
+  border-color: var(--sds-color-border-brand-default);
+}
+
+.supportToastButtonPrimary:hover {
+  background: var(--sds-color-background-brand-hover);
+  border-color: var(--sds-color-border-brand-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px var(--sds-color-black-300);
+}
+
+.supportToastButtonPrimary:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.supportToastButtonSecondary {
+  background: transparent;
+  color: var(--sds-color-text-default-secondary);
+  border-color: var(--sds-color-border-default-default);
+}
+
+.supportToastButtonSecondary:hover {
+  background: var(--sds-color-background-default-tertiary);
+  color: var(--sds-color-text-default-default);
+  border-color: var(--sds-color-border-default-hover);
+}
+
+.supportToastButtonSecondary:active {
+  background: var(--sds-color-background-default-secondary);
+}
+

--- a/src-2.0/types.ts
+++ b/src-2.0/types.ts
@@ -27,6 +27,16 @@ export interface GetJsonDataHandler extends EventHandler {
   ) => void;
 }
 
+export interface LaunchData {
+  launchCount: number;
+  hasSeenPrompt: boolean;
+}
+
+export interface LaunchDataHandler extends EventHandler {
+  name: "LAUNCH_DATA";
+  handler: (data: LaunchData) => void;
+}
+
 export interface TrackLaunchHandler extends EventHandler {
   name: "TRACK_LAUNCH";
   handler: () => void;

--- a/src-2.0/types.ts
+++ b/src-2.0/types.ts
@@ -37,6 +37,16 @@ export interface MarkSupportPromptSeenHandler extends EventHandler {
   handler: () => void;
 }
 
+export interface LaunchData {
+  launchCount: number;
+  hasSeenPrompt: boolean;
+}
+
+export interface LaunchDataHandler extends EventHandler {
+  name: "LAUNCH_DATA";
+  handler: (data: LaunchData) => void;
+}
+
 export type VariableViewMode = "table" | "css" | "json";
 export type ColorResolutionMode = "hex" | "rgba" | "hsla";
 

--- a/src-2.0/types.ts
+++ b/src-2.0/types.ts
@@ -27,6 +27,16 @@ export interface GetJsonDataHandler extends EventHandler {
   ) => void;
 }
 
+export interface TrackLaunchHandler extends EventHandler {
+  name: "TRACK_LAUNCH";
+  handler: () => void;
+}
+
+export interface MarkSupportPromptSeenHandler extends EventHandler {
+  name: "MARK_SUPPORT_PROMPT_SEEN";
+  handler: () => void;
+}
+
 export type VariableViewMode = "table" | "css" | "json";
 export type ColorResolutionMode = "hex" | "rgba" | "hsla";
 

--- a/src-2.0/types.ts
+++ b/src-2.0/types.ts
@@ -30,6 +30,7 @@ export interface GetJsonDataHandler extends EventHandler {
 export interface LaunchData {
   launchCount: number;
   hasSeenPrompt: boolean;
+  lastDismissLaunchCount: number | null;
 }
 
 export interface LaunchDataHandler extends EventHandler {
@@ -47,14 +48,9 @@ export interface MarkSupportPromptSeenHandler extends EventHandler {
   handler: () => void;
 }
 
-export interface LaunchData {
-  launchCount: number;
-  hasSeenPrompt: boolean;
-}
-
-export interface LaunchDataHandler extends EventHandler {
-  name: "LAUNCH_DATA";
-  handler: (data: LaunchData) => void;
+export interface DismissSupportPromptHandler extends EventHandler {
+  name: "DISMISS_SUPPORT_PROMPT";
+  handler: (currentLaunchCount: number) => void;
 }
 
 export type VariableViewMode = "table" | "css" | "json";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support toast appears after the third launch with Star, Sponsor, Remind Later and Close actions, social links, accessibility-aware animations, and configurable auto-dismiss.
  * Launch-tracking and prompt lifecycle controls (show, mark seen, dismiss) integrated.

* **New Components**
  * Loading spinner component for loading states.

* **Style**
  * Toast, spinner, skeletons, fade-in and other UI utilities added.

* **Refactor**
  * Header and SearchBar rendering simplified; loading state replaced with spinner in Variables view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->